### PR TITLE
Experimental support for the Etekcity EFS-A591S-KUS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,10 @@ src/.DS_Store
 .DS_Store
 
 test-esf551.py
+
+# --- Local-only working directories (do NOT commit) ---
+exploration_bin/
+.secrets/
+# Captures containing personal data (device MAC, weight readings)
+btsnoop_hci.log*
+*.jsonl

--- a/examples/connect_efsa591s_scale.py
+++ b/examples/connect_efsa591s_scale.py
@@ -100,8 +100,8 @@ async def scan_for_scale() -> str | None:
         if (any(h.upper() in name for h in SCALE_NAME_HINTS)
                 or SCALE_SERVICE in services
                 or ETEKCITY_MFR_ID in adv.manufacturer_data):
-            print(f"  Found: {dev.name or '?'} [{dev.address}]  "
-                  f"(mfr={', '.join(f'0x{k:04x}' for k in adv.manufacturer_data) or '-'})")
+            print(f"  Found: {dev.name or '?'} [{dev.address}]")
+            _dump_advertisement(adv)   # full payload, to identify the model
             return dev.address
 
     # Fall back to a device list to pick from.
@@ -109,13 +109,29 @@ async def scan_for_scale() -> str | None:
           "(strongest signal first):\n")
     rows = sorted(devices.values(), key=lambda da: -(da[1].rssi or -999))
     for dev, adv in rows:
-        mfr = ", ".join(f"0x{k:04x}" for k in adv.manufacturer_data) or "-"
+        mfr = _fmt_mfr(adv)
         print(f"  {dev.address}   rssi={adv.rssi:>4} dBm   "
-              f"name={(dev.name or '(none)'):<26} mfr={mfr}")
-    print("\nFind your scale above (likely the strongest signal when you're next "
-          "to it, often with no name), then re-run with its address:\n"
+              f"name={(dev.name or '(none)'):<26} mfr=[{mfr}]")
+    print("\nFind your scale above, then re-run with its address:\n"
           "  python connect_efsa591s_scale.py <ADDRESS> --lb")
     return None
+
+
+def _fmt_mfr(adv) -> str:
+    """Format manufacturer data as 'company_id=hexbytes' pairs."""
+    return ", ".join(f"0x{k:04x}={v.hex()}" for k, v in adv.manufacturer_data.items()) or "-"
+
+
+def _dump_advertisement(adv) -> None:
+    """Print the full advertisement payload (for model identification)."""
+    print("  ── advertisement details (for model identification) ──")
+    print(f"    manufacturer_data: {_fmt_mfr(adv)}")
+    svc_uuids = ", ".join(str(u) for u in adv.service_uuids) or "-"
+    print(f"    service_uuids    : {svc_uuids}")
+    svc_data = ", ".join(f"{u}={d.hex()}" for u, d in adv.service_data.items()) or "-"
+    print(f"    service_data     : {svc_data}")
+    print(f"    tx_power         : {adv.tx_power}")
+    print("  ──────────────────────────────────────────────────────")
 
 
 async def main(args: argparse.Namespace) -> None:

--- a/examples/connect_efsa591s_scale.py
+++ b/examples/connect_efsa591s_scale.py
@@ -18,6 +18,7 @@ from bleak import BleakScanner
 
 from etekcity_esf551_ble import EFSA591SScale, ScaleData, WeightUnit
 from etekcity_esf551_ble.const import IMPEDANCE_KEY, WEIGHT_KEY
+from etekcity_esf551_ble.efsa591s import a5_protocol as a5
 
 IMPEDANCE2_KEY = "impedance_100k"
 UserProfile = None  # legacy CLI arg compatibility; unused by encrypted client
@@ -134,6 +135,38 @@ def _dump_advertisement(adv) -> None:
     print("  ──────────────────────────────────────────────────────")
 
 
+class _FrameDumpMixin:
+    """Mix-in that prints every received frame (raw + decrypted) for protocol RE.
+
+    Used by --dump-frames to locate undocumented fields (e.g. heart rate). It
+    dumps before delegating to the normal handler, so it sees *all* opcodes,
+    including the status frames the client otherwise ignores (0x413b, etc.).
+    """
+
+    def _handle_frame(self, frame: bytes, name: str, address: str) -> None:
+        parsed = a5.parse_frame(frame)
+        if parsed is not None:
+            dec = ""
+            if parsed.channel == a5.CHANNEL_AES and self._key and self._iv:
+                try:
+                    dec = a5.decrypt_frame_payload(self._key, self._iv, parsed).hex()
+                except Exception as ex:  # pragma: no cover - diagnostic only
+                    dec = f"<decrypt failed: {ex}>"
+            print(
+                f"  [FRAME] seq=0x{parsed.seq:02x} op=0x{parsed.opcode:04x} "
+                f"ch=0x{parsed.channel:02x}  raw={frame.hex()}"
+                + (f"  dec={dec}" if dec else "")
+            )
+        super()._handle_frame(frame, name, address)
+
+
+def _make_scale(cls, **kwargs):
+    """Build the scale client, optionally wrapped with frame dumping."""
+    if kwargs.pop("_dump", False):
+        cls = type("_DumpingScale", (_FrameDumpMixin, cls), {})
+    return cls(**kwargs)
+
+
 async def main(args: argparse.Namespace) -> None:
     address = args.address
 
@@ -160,7 +193,13 @@ async def main(args: argparse.Namespace) -> None:
 
     today = date.today()
     birthdate = date(today.year - args.age, today.month, today.day)
-    scale = EFSA591SScaleWithBodyMetrics(
+    if args.dump_frames:
+        print("Frame-dump mode ON: printing raw + decrypted frames for every "
+              "packet. Stand on the scale and stay still until the reading "
+              "finishes (HR needs ~20-30 s), then step off and Ctrl+C.\n")
+    scale = _make_scale(
+        EFSA591SScaleWithBodyMetrics,
+        _dump=args.dump_frames,
         address=address,
         notification_callback=on_measurement,
         sex=Sex.Female if args.female else Sex.Male,
@@ -196,6 +235,9 @@ if __name__ == "__main__":
                         help="Set biological sex to female")
     parser.add_argument("--debug", action="store_true",
                         help="Enable verbose BLE debug logging")
+    parser.add_argument("--dump-frames", action="store_true",
+                        help="Print raw + decrypted hex of every frame "
+                             "(for protocol reverse-engineering, e.g. heart rate)")
     parser.add_argument("--log", action="store_true",
                         help="Capture all TX/RX packets + GATT table to a "
                              "timestamped .jsonl file for offline analysis")

--- a/examples/connect_efsa591s_scale.py
+++ b/examples/connect_efsa591s_scale.py
@@ -1,0 +1,195 @@
+"""
+Connect to the EFS-A591S-KUS scale and print live measurements.
+
+Usage:
+    python connect_efsa591s_scale.py                    # scan / list devices
+    python connect_efsa591s_scale.py CF:EA:01:28:86:45  # use known MAC address
+    python connect_efsa591s_scale.py <MAC> --lb         # display in pounds
+    python connect_efsa591s_scale.py <MAC> --height 175 --age 30 --female
+"""
+
+import argparse
+import asyncio
+import logging
+import sys
+from datetime import datetime
+
+from bleak import BleakScanner
+
+from etekcity_esf551_ble import EFSA591SScale, ScaleData, WeightUnit
+from etekcity_esf551_ble.const import IMPEDANCE_KEY, WEIGHT_KEY
+
+IMPEDANCE2_KEY = "impedance_100k"
+UserProfile = None  # legacy CLI arg compatibility; unused by encrypted client
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+_LOGGER = logging.getLogger(__name__)
+
+
+SCALE_NAME_HINTS = ("Etekcity", "Smart Fitness Scale", "EFS-A591S", "Apex")
+SCALE_SERVICE = "0000fff0-0000-1000-8000-00805f9b34fb"
+# Etekcity Corporation's Bluetooth SIG company identifier (start of mfr data).
+# Shared across Etekcity scales, so it matches "an Etekcity scale", not this
+# model specifically — fine when you only have one Etekcity scale nearby.
+ETEKCITY_MFR_ID = 0x06D0
+
+
+def on_measurement(data: ScaleData) -> None:
+    m = data.measurements
+    weight_kg = m.get(WEIGHT_KEY)  # library always reports weight in kg
+    imp1 = m.get(IMPEDANCE_KEY)
+    imp2 = m.get(IMPEDANCE2_KEY)
+
+    # Convert the kg value to the requested display unit.
+    factor, unit_label = {
+        WeightUnit.KG: (1.0, "kg"),
+        WeightUnit.LB: (2.2046226, "lb"),
+        WeightUnit.ST: (0.15747304, "st"),
+    }.get(data.display_unit, (1.0, "kg"))
+
+    if weight_kg:
+        parts = [f"Weight: {weight_kg * factor:.2f} {unit_label}  ({weight_kg:.2f} kg)"]
+    else:
+        parts = ["Weight: --"]
+    if imp1:
+        parts.append(f"Impedance: {imp1} Ω")
+    if imp2:
+        parts.append(f"Impedance (100 kHz): {imp2} Ω")
+
+    # Any computed body metrics (present only with the body-metrics wrapper).
+    metric_labels = {
+        "body_mass_index": "BMI",
+        "body_fat_percentage": "Body fat %",
+        "skeletal_muscle_percentage": "Skeletal muscle %",
+        "muscle_mass": "Muscle mass (kg)",
+        "body_water_percentage": "Body water %",
+        "basal_metabolic_rate": "BMR (kcal)",
+        "visceral_fat_value": "Visceral fat",
+        "subcutaneous_fat_percentage": "Subcutaneous fat %",
+        "fat_free_weight": "Fat-free weight (kg)",
+    }
+    for key, label in metric_labels.items():
+        if key in m:
+            parts.append(f"{label}: {m[key]}")
+
+    print("\n" + "─" * 40)
+    print(f"  {data.name}  [{data.address}]")
+    for p in parts:
+        print(f"  {p}")
+    print("─" * 40)
+
+
+async def scan_for_scale() -> str | None:
+    """
+    Scan for the scale and return its MAC address.
+
+    Auto-matches on the advertised local name ("Etekcity Smart Fitness Scale"),
+    the FFF0 service UUID, or Etekcity's manufacturer ID (0x06D0). Falls back to
+    listing nearby devices if nothing matches. Wake the scale first (step on it)
+    so it advertises.
+    """
+    print("Scanning 10 s…  (step on the scale so it advertises)")
+    devices = await BleakScanner.discover(timeout=10.0, return_adv=True)
+
+    for dev, adv in devices.values():
+        name = (dev.name or "").upper()
+        services = [str(s).lower() for s in adv.service_uuids]
+        if (any(h.upper() in name for h in SCALE_NAME_HINTS)
+                or SCALE_SERVICE in services
+                or ETEKCITY_MFR_ID in adv.manufacturer_data):
+            print(f"  Found: {dev.name or '?'} [{dev.address}]  "
+                  f"(mfr={', '.join(f'0x{k:04x}' for k in adv.manufacturer_data) or '-'})")
+            return dev.address
+
+    # Fall back to a device list to pick from.
+    print("\nCould not auto-identify the scale. Nearby BLE devices "
+          "(strongest signal first):\n")
+    rows = sorted(devices.values(), key=lambda da: -(da[1].rssi or -999))
+    for dev, adv in rows:
+        mfr = ", ".join(f"0x{k:04x}" for k in adv.manufacturer_data) or "-"
+        print(f"  {dev.address}   rssi={adv.rssi:>4} dBm   "
+              f"name={(dev.name or '(none)'):<26} mfr={mfr}")
+    print("\nFind your scale above (likely the strongest signal when you're next "
+          "to it, often with no name), then re-run with its address:\n"
+          "  python connect_efsa591s_scale.py <ADDRESS> --lb")
+    return None
+
+
+async def main(args: argparse.Namespace) -> None:
+    address = args.address
+
+    if not address:
+        address = await scan_for_scale()
+        if not address:
+            print(
+                "Scale not found. Make sure it is powered on (step on it briefly to wake it),\n"
+                "then try again or supply the MAC address as an argument."
+            )
+            sys.exit(1)
+
+    unit = WeightUnit.LB if args.lb else (WeightUnit.ST if args.st else WeightUnit.KG)
+
+    print(f"Connecting to scale at {address}…")
+    print(f"Display unit: {unit.name}")
+    print("Step onto the scale when ready. Press Ctrl+C to quit.\n")
+
+    # With body metrics: pass height/age/sex to compute BMI, body fat, etc.
+    from datetime import date
+
+    from etekcity_esf551_ble import EFSA591SScaleWithBodyMetrics
+    from etekcity_esf551_ble.esf551.body_metrics import Sex
+
+    today = date.today()
+    birthdate = date(today.year - args.age, today.month, today.day)
+    scale = EFSA591SScaleWithBodyMetrics(
+        address=address,
+        notification_callback=on_measurement,
+        sex=Sex.Female if args.female else Sex.Male,
+        birthdate=birthdate,
+        height_m=args.height / 100.0,
+        display_unit=unit,
+    )
+
+    await scale.async_start()
+    try:
+        await asyncio.Event().wait()  # run until Ctrl+C
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        pass
+    finally:
+        await scale.async_stop()
+        print("\nDisconnected.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="EFS-A591S-KUS scale reader")
+    parser.add_argument(
+        "address", nargs="?", default="",
+        help="BLE MAC address of the scale (e.g. CF:EA:01:28:86:45). "
+             "If omitted, a scan is performed."
+    )
+    parser.add_argument("--lb", action="store_true", help="Display weight in pounds")
+    parser.add_argument("--st", action="store_true", help="Display weight in stones")
+    parser.add_argument("--height", type=int, default=170, metavar="CM",
+                        help="Your height in cm (default: 170)")
+    parser.add_argument("--age", type=int, default=30,
+                        help="Your age in years (default: 30)")
+    parser.add_argument("--female", action="store_true",
+                        help="Set biological sex to female")
+    parser.add_argument("--debug", action="store_true",
+                        help="Enable verbose BLE debug logging")
+    parser.add_argument("--log", action="store_true",
+                        help="Capture all TX/RX packets + GATT table to a "
+                             "timestamped .jsonl file for offline analysis")
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.getLogger("etekcity_esf551_ble").setLevel(logging.DEBUG)
+        # Keep connection/GATT events from the bleak client; silence the scanner
+        # which emits a "Received <MAC>" line for every nearby advertisement.
+        logging.getLogger("bleak.backends.winrt.client").setLevel(logging.DEBUG)
+        logging.getLogger("bleak.backends.winrt.scanner").setLevel(logging.WARNING)
+
+    asyncio.run(main(args))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
 dependencies = [
     "bleak>=2.0.0,<4.0.0",
     "bleak_retry_connector>=3.0.0",
+    "cryptography>=41.0.0",
 ]
 
 [tool.hatch.version]

--- a/src/etekcity_esf551_ble/__init__.py
+++ b/src/etekcity_esf551_ble/__init__.py
@@ -8,6 +8,7 @@ from .const import (
 )
 from .esf24 import ESF24Scale
 from .fit8s import FIT8SScale
+from .efsa591s import EFSA591SScale, EFSA591SScaleWithBodyMetrics
 from .parser import (
     AdvertisementScale,
     BluetoothScanningMode,
@@ -27,6 +28,8 @@ __all__ = [
     "ESF24Scale",
     "FIT8SScale",
     "ESF551ScaleWithBodyMetrics",
+    "EFSA591SScale",
+    "EFSA591SScaleWithBodyMetrics",
     "WeightUnit",
     "ScaleData",
     "IMPEDANCE_KEY",

--- a/src/etekcity_esf551_ble/__init__.py
+++ b/src/etekcity_esf551_ble/__init__.py
@@ -3,6 +3,7 @@ from .esf551 import ESF551Scale, ESF551ScaleWithBodyMetrics
 from .esf551.body_metrics import BodyMetrics, Sex
 from .const import (
     DISPLAY_UNIT_KEY,
+    HEART_RATE_KEY,
     IMPEDANCE_KEY,
     WEIGHT_KEY,
 )
@@ -32,6 +33,7 @@ __all__ = [
     "EFSA591SScaleWithBodyMetrics",
     "WeightUnit",
     "ScaleData",
+    "HEART_RATE_KEY",
     "IMPEDANCE_KEY",
     "WEIGHT_KEY",
     "BodyMetrics",

--- a/src/etekcity_esf551_ble/_version.py
+++ b/src/etekcity_esf551_ble/_version.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 
 def _parse_version_info(version_str: str) -> tuple[int, ...]:

--- a/src/etekcity_esf551_ble/_version.py
+++ b/src/etekcity_esf551_ble/_version.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 
 def _parse_version_info(version_str: str) -> tuple[int, ...]:

--- a/src/etekcity_esf551_ble/const.py
+++ b/src/etekcity_esf551_ble/const.py
@@ -4,9 +4,11 @@ ALIRO_CHARACTERISTIC_UUID = "0000fff2-0000-1000-8000-00805f9b34fb"
 DISPLAY_UNIT_KEY = "display_unit"
 WEIGHT_KEY = "weight"
 IMPEDANCE_KEY = "impedance"
+HEART_RATE_KEY = "heart_rate"
 
 __all__ = [
     "DISPLAY_UNIT_KEY",
+    "HEART_RATE_KEY",
     "IMPEDANCE_KEY",
     "WEIGHT_KEY",
 ]

--- a/src/etekcity_esf551_ble/efsa591s/__init__.py
+++ b/src/etekcity_esf551_ble/efsa591s/__init__.py
@@ -1,0 +1,10 @@
+"""EFS-A591S-KUS (Apex HR Smart Fitness Scale) support."""
+
+from . import a5_protocol
+from .scale import EFSA591SScale, EFSA591SScaleWithBodyMetrics
+
+__all__ = [
+    "EFSA591SScale",
+    "EFSA591SScaleWithBodyMetrics",
+    "a5_protocol",
+]

--- a/src/etekcity_esf551_ble/efsa591s/a5_protocol.py
+++ b/src/etekcity_esf551_ble/efsa591s/a5_protocol.py
@@ -256,6 +256,7 @@ class Measurement(NamedTuple):
     timestamp: int
     final: bool            # True for the 0x443a result frame
     raw: bytes
+    heart_rate: int | None = None  # bpm, present on the final result once measured
 
 
 def decrypt_frame_payload(key: bytes, iv: bytes, parsed: ParsedFrame) -> bytes:
@@ -286,15 +287,19 @@ def parse_result(plaintext: bytes) -> Measurement | None:
 
     Layout (38 bytes): [0:8]=serial ascii, [8:20]=name, [20:22]=00,
     [22:25]=weight grams (uint24 LE) /1000 kg, [25:27]=impedance (uint16 LE) ohms,
-    [29:33]=timestamp.
+    [29:33]=timestamp, [36]=heart rate (bpm, 0 until measured).
     """
     if len(plaintext) < 33:
         return None
     weight = int.from_bytes(plaintext[22:25], "little") / 1000.0
     impedance = struct.unpack("<H", plaintext[25:27])[0]
     timestamp = struct.unpack("<I", plaintext[29:33])[0]
+    # Heart rate is one byte near the end of the frame; 0 means "not measured"
+    # (e.g. user stepped off before it locked, or not barefoot on the electrodes).
+    heart_rate = plaintext[36] if len(plaintext) >= 37 and plaintext[36] else None
     return Measurement(
         weight_kg=round(weight, 2),
         impedance=impedance if 0 < impedance < 60000 else None,
         timestamp=timestamp, final=True, raw=plaintext,
+        heart_rate=heart_rate,
     )

--- a/src/etekcity_esf551_ble/efsa591s/a5_protocol.py
+++ b/src/etekcity_esf551_ble/efsa591s/a5_protocol.py
@@ -1,0 +1,300 @@
+"""
+A5 encrypted transport for the EFS-A591S-KUS (Apex HR) scale.
+
+The scale uses an "A5" RPC framing over GATT FFF1 (notify) / FFF2 (write);
+measurement data is AES-128-CBC encrypted with a key established by a
+small-number Diffie-Hellman handshake.
+
+Handshake / crypto summary
+--------------------------
+1. Client sends KEY_EXCHANGE (0x4201) carrying a small-number DH: modulus ``d``
+   (prime, 40000-46340), base ``e`` (prime, 10-100), and ``f = e**g mod d``
+   where ``g`` is the client's secret exponent (5-20).
+2. Scale replies with its public value ``h``.
+3. shared = h**g mod d  ->  key = SHA256(f"{shared}".encode() + b"," + reversed_mac)[:16]
+4. Client generates a random 16-byte IV and sends it in KEY_VERIFY (0x4202),
+   encrypted with (key, zero-IV).
+5. Measurement frames (0x4421) are AES-CBC(key, iv); weight = uint24_le(pt[0:3]) / 1000 kg.
+
+This module is transport-agnostic and side-effect free so it can be unit tested
+against captured frames.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+import struct
+import time
+from typing import NamedTuple
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+# ---- protocol constants ---------------------------------------------------
+
+A5_MAGIC = 0xA5
+FLAG_APP_WRITE = 0x23
+
+OPCODE_KEY_EXCHANGE = 0x4201   # OP_HIGH_SECURITY_KEY_EXCHANGE
+OPCODE_KEY_VERIFY = 0x4202     # OP_HIGH_SECURITY_KEY_VERIFY
+OPCODE_MEASUREMENT = 0x4421    # live weight push (resource 21 44 00)
+OPCODE_RESULT = 0x443a         # final result: weight + impedance (resource 3a 44 00)
+
+CHANNEL_PLAINTEXT = 0x00
+CHANNEL_AES = 0x01             # the AES-encrypted measurement channel
+
+# DH parameter ranges
+DH_MOD_MIN, DH_MOD_MAX = 40000, 46340   # prime modulus d
+DH_BASE_MIN, DH_BASE_MAX = 10, 100      # prime base e
+DH_EXP_MIN, DH_EXP_MAX = 5, 20          # secret exponent g
+
+
+# ---- framing --------------------------------------------------------------
+
+def _checksum(frame_without_cksum: bytes) -> int:
+    """byte[5] is set so the sum of all frame bytes ≡ 0xFF (mod 256)."""
+    return (0xFF - (sum(frame_without_cksum) & 0xFF)) & 0xFF
+
+
+def build_frame(seq: int, opcode: int, payload: bytes, channel: int) -> bytes:
+    """
+    Assemble an A5 frame:
+        [0]=0xA5 [1]=flags [2]=seq [3:5]=len(LE) [5]=checksum
+        [6]=0x01 [7:9]=opcode(LE) [9]=0x00 [10]=channel [11:]=payload
+    where len = total - 6.
+    """
+    body = bytes([0x01]) + struct.pack("<H", opcode) + bytes([0x00, channel]) + payload
+    header = bytes([A5_MAGIC, FLAG_APP_WRITE, seq & 0xFF]) + struct.pack("<H", len(body))
+    frame = bytearray(header + bytes([0x00]) + body)  # 0x00 = checksum placeholder
+    frame[5] = _checksum(frame)
+    return bytes(frame)
+
+
+class ParsedFrame(NamedTuple):
+    flags: int
+    seq: int
+    opcode: int
+    channel: int
+    payload: bytes
+
+
+def parse_frame(data: bytes) -> ParsedFrame | None:
+    """Parse a complete A5 frame (after reassembly). Returns None if malformed."""
+    if len(data) < 11 or data[0] != A5_MAGIC:
+        return None
+    length = struct.unpack("<H", data[3:5])[0]
+    if len(data) != length + 6:
+        return None
+    opcode = struct.unpack("<H", data[7:9])[0]
+    return ParsedFrame(
+        flags=data[1], seq=data[2], opcode=opcode, channel=data[10], payload=data[11:]
+    )
+
+
+class FrameReassembler:
+    """Reassemble A5 frames from BLE notification fragments (total = len + 6)."""
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+        self._expected = 0
+
+    def feed(self, chunk: bytes):
+        """Feed one notification payload; yield each complete frame."""
+        for b in chunk:
+            if not self._buf:
+                if b != A5_MAGIC:
+                    continue
+                self._buf.append(b)
+            else:
+                self._buf.append(b)
+                if len(self._buf) == 5:
+                    self._expected = struct.unpack("<H", bytes(self._buf[3:5]))[0] + 6
+                if self._expected and len(self._buf) == self._expected:
+                    frame = bytes(self._buf)
+                    self._buf = bytearray()
+                    self._expected = 0
+                    yield frame
+
+
+# ---- AES ------------------------------------------------------------------
+
+def _aes_cbc_decrypt(key: bytes, iv: bytes, ciphertext: bytes) -> bytes:
+    dec = Cipher(algorithms.AES(key), modes.CBC(iv)).decryptor()
+    return dec.update(ciphertext) + dec.finalize()
+
+
+def _aes_cbc_encrypt(key: bytes, iv: bytes, plaintext: bytes) -> bytes:
+    enc = Cipher(algorithms.AES(key), modes.CBC(iv)).encryptor()
+    return enc.update(plaintext) + enc.finalize()
+
+
+def _pkcs7_pad(data: bytes, block: int = 16) -> bytes:
+    pad = block - (len(data) % block)
+    return data + bytes([pad]) * pad
+
+
+def _pkcs7_unpad(data: bytes) -> bytes:
+    if not data:
+        return data
+    pad = data[-1]
+    if 1 <= pad <= 16 and data[-pad:] == bytes([pad]) * pad:
+        return data[:-pad]
+    return data
+
+
+# ---- MAC / Diffie-Hellman / key derivation --------------------------------
+
+def reversed_mac_bytes(mac: str) -> bytes:
+    """'CF:EA:01:28:86:45' -> b'\\x45\\x86\\x28\\x01\\xea\\xcf' (reversed octets)."""
+    octets = bytes(int(x, 16) for x in mac.split(":"))
+    return octets[::-1]
+
+
+def _is_prime(n: int) -> bool:
+    if n < 2:
+        return False
+    if n % 2 == 0:
+        return n == 2
+    i = 3
+    while i * i <= n:
+        if n % i == 0:
+            return False
+        i += 2
+    return True
+
+
+def _rand_prime(lo: int, hi: int) -> int:
+    while True:
+        n = secrets.randbelow(hi - lo + 1) + lo
+        if _is_prime(n):
+            return n
+
+
+class DHParams(NamedTuple):
+    d: int  # prime modulus
+    e: int  # prime base
+    g: int  # secret exponent
+    f: int  # public value = e**g mod d
+
+
+def generate_dh() -> DHParams:
+    d = _rand_prime(DH_MOD_MIN, DH_MOD_MAX)
+    e = _rand_prime(DH_BASE_MIN, DH_BASE_MAX)
+    g = secrets.randbelow(DH_EXP_MAX - DH_EXP_MIN + 1) + DH_EXP_MIN
+    return DHParams(d=d, e=e, g=g, f=pow(e, g, d))
+
+
+def compute_shared(scale_public_h: int, g: int, d: int) -> int:
+    return pow(scale_public_h, g, d)
+
+
+def derive_key(shared: int, mac: str) -> bytes:
+    digest = hashlib.sha256(str(shared).encode() + b"," + reversed_mac_bytes(mac)).digest()
+    return digest[:16]
+
+
+# ---- handshake messages ---------------------------------------------------
+
+def _tz_byte() -> int:
+    """Local UTC offset encoded as the app does: rawOffset_seconds * 2 / 3600."""
+    off = -time.timezone if time.localtime().tm_isdst == 0 else -time.altzone
+    return (off * 2 // 3600) & 0xFF
+
+
+def build_key_exchange(seq: int, mac: str, dh: DHParams) -> bytes:
+    """OP_HIGH_SECURITY_KEY_EXCHANGE (0x4201), plaintext channel."""
+    rmac = reversed_mac_bytes(mac)
+    ts = int(time.time())
+    payload = (
+        struct.pack("<I", ts)
+        + bytes([_tz_byte(), len(rmac)])
+        + rmac
+        + struct.pack("<H", dh.d)
+        + bytes([dh.e])
+        + struct.pack("<H", dh.f)
+    )
+    return build_frame(seq, OPCODE_KEY_EXCHANGE, payload, CHANNEL_PLAINTEXT)
+
+
+def parse_key_exchange_response(frame: bytes) -> int | None:
+    """Extract the scale's public value h from a 0x4201 response frame."""
+    parsed = parse_frame(frame)
+    if parsed is None or parsed.opcode != OPCODE_KEY_EXCHANGE:
+        return None
+    r = parsed.payload
+    if len(r) < 2:
+        return None
+    p = r[1]  # mac length
+    if len(r) < p + 4:
+        return None
+    return struct.unpack("<H", r[p + 2:p + 4])[0]
+
+
+def build_key_verify(seq: int, mac: str, iv: bytes, key: bytes) -> bytes:
+    """
+    OP_HIGH_SECURITY_KEY_VERIFY (0x4202): deliver our random IV to the scale.
+
+    Inner payload = [0x0c][reversed_mac(6)][0x10][iv(16)], AES-CBC encrypted with
+    (key, zero-IV), sent on the AES channel.
+    """
+    rmac = reversed_mac_bytes(mac)
+    inner = bytes([0x0C]) + rmac + bytes([len(iv)]) + iv
+    ciphertext = _aes_cbc_encrypt(key, bytes(16), _pkcs7_pad(inner))
+    return build_frame(seq, OPCODE_KEY_VERIFY, ciphertext, CHANNEL_AES)
+
+
+def random_iv() -> bytes:
+    return os.urandom(16)
+
+
+# ---- measurement decoding -------------------------------------------------
+
+class Measurement(NamedTuple):
+    weight_kg: float
+    impedance: int | None  # whole-body impedance in ohms (final result only)
+    timestamp: int
+    final: bool            # True for the 0x443a result frame
+    raw: bytes
+
+
+def decrypt_frame_payload(key: bytes, iv: bytes, parsed: ParsedFrame) -> bytes:
+    ct = parsed.payload
+    ct = ct[: len(ct) // 16 * 16]
+    return _pkcs7_unpad(_aes_cbc_decrypt(key, iv, ct))
+
+
+def parse_measurement(plaintext: bytes) -> Measurement | None:
+    """
+    Decode a decrypted live-weight frame (0x4421).
+
+    Layout (16 bytes): [0:3]=weight grams (uint24 LE) /1000 kg, [7:11]=timestamp.
+    """
+    if len(plaintext) < 11:
+        return None
+    weight = int.from_bytes(plaintext[0:3], "little") / 1000.0
+    timestamp = struct.unpack("<I", plaintext[7:11])[0]
+    return Measurement(
+        weight_kg=round(weight, 2), impedance=None,
+        timestamp=timestamp, final=False, raw=plaintext,
+    )
+
+
+def parse_result(plaintext: bytes) -> Measurement | None:
+    """
+    Decode a decrypted final-result frame (0x443a).
+
+    Layout (38 bytes): [0:8]=serial ascii, [8:20]=name, [20:22]=00,
+    [22:25]=weight grams (uint24 LE) /1000 kg, [25:27]=impedance (uint16 LE) ohms,
+    [29:33]=timestamp.
+    """
+    if len(plaintext) < 33:
+        return None
+    weight = int.from_bytes(plaintext[22:25], "little") / 1000.0
+    impedance = struct.unpack("<H", plaintext[25:27])[0]
+    timestamp = struct.unpack("<I", plaintext[29:33])[0]
+    return Measurement(
+        weight_kg=round(weight, 2),
+        impedance=impedance if 0 < impedance < 60000 else None,
+        timestamp=timestamp, final=True, raw=plaintext,
+    )

--- a/src/etekcity_esf551_ble/efsa591s/scale.py
+++ b/src/etekcity_esf551_ble/efsa591s/scale.py
@@ -28,6 +28,10 @@ from . import a5_protocol as a5
 
 _LOGGER = logging.getLogger(__name__)
 
+# Frames the scale emits that carry no data we use (status/flag/ack frames).
+# Ignored silently so they don't spam the debug log.
+_STATUS_OPCODES = frozenset({0x4202, 0x4420, 0x413b, 0x413d, 0x4434, 0x4436})
+
 
 class EFSA591SScale(GattScale):
     """
@@ -52,7 +56,6 @@ class EFSA591SScale(GattScale):
         self._dh: a5.DHParams | None = None
         self._key: bytes | None = None
         self._iv: bytes | None = None
-        self._last_weight: float | None = None
 
     def _next_seq(self) -> int:
         self._seq = (self._seq + 1) & 0xFF
@@ -114,7 +117,8 @@ class EFSA591SScale(GattScale):
         name: str,
         address: str,
     ) -> None:
-        for frame in self._reasm.feed(bytes(data)):
+        # data is a bytearray; FrameReassembler.feed iterates it, so no copy needed.
+        for frame in self._reasm.feed(data):
             try:
                 self._handle_frame(frame, name, address)
             except Exception as ex:  # pragma: no cover - defensive
@@ -138,24 +142,31 @@ class EFSA591SScale(GattScale):
             )
             asyncio.ensure_future(self._send_frame(verify))
 
-        elif parsed.opcode in (a5.OPCODE_MEASUREMENT, a5.OPCODE_RESULT):
+        elif parsed.opcode == a5.OPCODE_RESULT:
+            # Only the final result frame carries the stabilized weight plus
+            # impedance. We deliberately apply ONLY this frame and ignore the
+            # live OPCODE_MEASUREMENT stream below: those intermediate frames
+            # carry an unstable, weight-only reading that would otherwise flood
+            # history and overwrite the final body-composition values (a live
+            # frame arriving after the result frame resets impedance to
+            # "unavailable").
             if not self._key or not self._iv:
                 return
             pt = a5.decrypt_frame_payload(self._key, self._iv, parsed)
-            if parsed.opcode == a5.OPCODE_RESULT:
-                meas = a5.parse_result(pt)
-            else:
-                meas = a5.parse_measurement(pt)
+            meas = a5.parse_result(pt)
             if meas is None or meas.weight_kg <= 0:
                 return
             self._emit(meas, name, address)
-        else:
+        elif parsed.opcode == a5.OPCODE_MEASUREMENT:
+            # Live, pre-stabilization weight stream - intentionally ignored so
+            # only the finalized measurement is delivered to Home Assistant.
+            return
+        elif parsed.opcode not in _STATUS_OPCODES:
             _LOGGER.debug(
                 "EFS-A591S unhandled opcode 0x%04x: %s", parsed.opcode, frame.hex()
             )
 
     def _emit(self, meas: a5.Measurement, name: str, address: str) -> None:
-        self._last_weight = meas.weight_kg
         scale_data = ScaleData()
         scale_data.name = name
         scale_data.address = address

--- a/src/etekcity_esf551_ble/efsa591s/scale.py
+++ b/src/etekcity_esf551_ble/efsa591s/scale.py
@@ -13,6 +13,7 @@ from bleak.backends.scanner import BaseBleakScanner
 
 from ..const import (
     ALIRO_CHARACTERISTIC_UUID,
+    HEART_RATE_KEY,
     IMPEDANCE_KEY,
     WEIGHT_CHARACTERISTIC_UUID_NOTIFY,
     WEIGHT_KEY,
@@ -176,6 +177,8 @@ class EFSA591SScale(GattScale):
         measurements: dict[str, float | int] = {WEIGHT_KEY: meas.weight_kg}
         if meas.impedance:
             measurements[IMPEDANCE_KEY] = meas.impedance
+        if meas.heart_rate:
+            measurements[HEART_RATE_KEY] = meas.heart_rate
         scale_data.measurements = measurements
         self._notification_callback(scale_data)
 

--- a/src/etekcity_esf551_ble/efsa591s/scale.py
+++ b/src/etekcity_esf551_ble/efsa591s/scale.py
@@ -1,0 +1,224 @@
+"""EFS-A591S-KUS (Apex HR) scale — encrypted A5 GATT client."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from datetime import date
+
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import BaseBleakScanner
+
+from ..const import (
+    ALIRO_CHARACTERISTIC_UUID,
+    IMPEDANCE_KEY,
+    WEIGHT_CHARACTERISTIC_UUID_NOTIFY,
+    WEIGHT_KEY,
+)
+from ..parser import BluetoothScanningMode, GattScale, ScaleData, WeightUnit
+from ..esf551.body_metrics import (
+    BodyMetrics,
+    Sex,
+    _as_dictionary,
+    _calc_age,
+)
+from . import a5_protocol as a5
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EFSA591SScale(GattScale):
+    """
+    EFS-A591S-KUS (Apex HR Smart Fitness Scale).
+
+    Speaks the scale's "A5" encrypted protocol over GATT FFF0
+    (notify FFF1 / write FFF2).  On connect it performs a small-number
+    Diffie-Hellman handshake, derives an AES-128-CBC session key from the
+    exchange and the device MAC, sends a randomly generated session IV, then
+    decrypts the live weight stream.
+
+    Note: key derivation requires the device's real MAC address, so this model
+    does not work on platforms where bleak reports a CoreBluetooth UUID instead
+    of a MAC (i.e. macOS without ``use_bdaddr``).
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._write_char = None
+        self._reasm = a5.FrameReassembler()
+        self._seq = 0x0A
+        self._dh: a5.DHParams | None = None
+        self._key: bytes | None = None
+        self._iv: bytes | None = None
+        self._last_weight: float | None = None
+
+    def _next_seq(self) -> int:
+        self._seq = (self._seq + 1) & 0xFF
+        return self._seq
+
+    async def _start_scale_session(self, ble_device: BLEDevice) -> None:
+        try:
+            _LOGGER.debug(
+                "EFS-A591S session for %s (%s)", ble_device.name, ble_device.address
+            )
+            if ":" not in self.address:
+                _LOGGER.error(
+                    "EFS-A591S needs the device MAC for key derivation; got '%s'. "
+                    "This platform does not expose a MAC (e.g. macOS).",
+                    self.address,
+                )
+                return
+
+            notify_char = self._client.services.get_characteristic(
+                WEIGHT_CHARACTERISTIC_UUID_NOTIFY
+            )
+            self._write_char = self._client.services.get_characteristic(
+                ALIRO_CHARACTERISTIC_UUID
+            )
+            if not notify_char or not self._write_char:
+                _LOGGER.error("EFS-A591S required characteristics not found")
+                return
+
+            # Reset per-session crypto state
+            self._reasm = a5.FrameReassembler()
+            self._key = None
+            self._iv = None
+
+            await self._client.start_notify(
+                notify_char,
+                lambda char, data: self._notification_handler(
+                    char, data, ble_device.name, ble_device.address
+                ),
+            )
+
+            # Kick off the DH key exchange
+            self._dh = a5.generate_dh()
+            frame = a5.build_key_exchange(self._next_seq(), self.address, self._dh)
+            _LOGGER.debug("EFS-A591S sending key exchange: %s", frame.hex())
+            await self._send_frame(frame)
+
+        except Exception as ex:
+            _LOGGER.exception("EFS-A591S session setup failed: %s(%s)", type(ex), ex.args)
+            self._client = None
+
+    async def _send_frame(self, frame: bytes) -> None:
+        if self._client and self._write_char:
+            await self._client.write_gatt_char(self._write_char, frame, response=False)
+
+    def _notification_handler(
+        self,
+        _: BleakGATTCharacteristic,
+        data: bytearray,
+        name: str,
+        address: str,
+    ) -> None:
+        for frame in self._reasm.feed(bytes(data)):
+            try:
+                self._handle_frame(frame, name, address)
+            except Exception as ex:  # pragma: no cover - defensive
+                _LOGGER.debug("EFS-A591S frame handling error: %s", ex)
+
+    def _handle_frame(self, frame: bytes, name: str, address: str) -> None:
+        parsed = a5.parse_frame(frame)
+        if parsed is None:
+            return
+
+        if parsed.opcode == a5.OPCODE_KEY_EXCHANGE:
+            h = a5.parse_key_exchange_response(frame)
+            if h is None or self._dh is None:
+                return
+            shared = a5.compute_shared(h, self._dh.g, self._dh.d)
+            self._key = a5.derive_key(shared, self.address)
+            self._iv = a5.random_iv()
+            _LOGGER.debug("EFS-A591S key established (h=%d), sending verify", h)
+            verify = a5.build_key_verify(
+                self._next_seq(), self.address, self._iv, self._key
+            )
+            asyncio.ensure_future(self._send_frame(verify))
+
+        elif parsed.opcode in (a5.OPCODE_MEASUREMENT, a5.OPCODE_RESULT):
+            if not self._key or not self._iv:
+                return
+            pt = a5.decrypt_frame_payload(self._key, self._iv, parsed)
+            if parsed.opcode == a5.OPCODE_RESULT:
+                meas = a5.parse_result(pt)
+            else:
+                meas = a5.parse_measurement(pt)
+            if meas is None or meas.weight_kg <= 0:
+                return
+            self._emit(meas, name, address)
+        else:
+            _LOGGER.debug(
+                "EFS-A591S unhandled opcode 0x%04x: %s", parsed.opcode, frame.hex()
+            )
+
+    def _emit(self, meas: a5.Measurement, name: str, address: str) -> None:
+        self._last_weight = meas.weight_kg
+        scale_data = ScaleData()
+        scale_data.name = name
+        scale_data.address = address
+        scale_data.hw_version = self.hw_version or ""
+        scale_data.sw_version = self.sw_version or ""
+        scale_data.display_unit = self._display_unit
+        measurements: dict[str, float | int] = {WEIGHT_KEY: meas.weight_kg}
+        if meas.impedance:
+            measurements[IMPEDANCE_KEY] = meas.impedance
+        scale_data.measurements = measurements
+        self._notification_callback(scale_data)
+
+
+class EFSA591SScaleWithBodyMetrics(EFSA591SScale):
+    """
+    EFS-A591S-KUS with on-device body-composition calculation.
+
+    Wraps :class:`EFSA591SScale` and, when an impedance value is present (i.e. on
+    the final result frame), augments ``ScaleData.measurements`` with body
+    metrics (BMI, body-fat %, muscle mass, etc.) computed locally from the user's
+    profile using the same :class:`BodyMetrics` engine as the ESF-551.  Frames
+    that carry weight only (the live stream) get BMI added.
+    """
+
+    def __init__(
+        self,
+        address: str,
+        notification_callback: Callable[[ScaleData], None],
+        sex: Sex,
+        birthdate: date,
+        height_m: float,
+        display_unit: WeightUnit = None,
+        scanning_mode: BluetoothScanningMode = BluetoothScanningMode.ACTIVE,
+        adapter: str | None = None,
+        bleak_scanner_backend: BaseBleakScanner = None,
+        cooldown_seconds: int = 0,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._sex = sex
+        self._birthdate = birthdate
+        self._height_m = height_m
+        self._original_callback = notification_callback
+        super().__init__(
+            address,
+            self._wrapped_callback,
+            display_unit,
+            scanning_mode,
+            adapter,
+            bleak_scanner_backend,
+            cooldown_seconds,
+            logger,
+        )
+
+    def _wrapped_callback(self, data: ScaleData) -> None:
+        metrics = BodyMetrics(
+            data.measurements[WEIGHT_KEY],
+            self._height_m,
+            _calc_age(self._birthdate),
+            self._sex,
+            data.measurements.get(IMPEDANCE_KEY),
+        )
+        if IMPEDANCE_KEY in data.measurements:
+            data.measurements |= _as_dictionary(metrics)
+        else:
+            data.measurements["body_mass_index"] = metrics.body_mass_index
+        self._original_callback(data)

--- a/tests/unit/test_efsa591s_a5_protocol.py
+++ b/tests/unit/test_efsa591s_a5_protocol.py
@@ -1,0 +1,146 @@
+"""
+Unit tests for the EFS-A591S A5 encrypted transport, validated against real
+captured frames from a live measurement session.
+
+Session-1 ground truth (recovered from captured frames):
+    MAC      = CF:EA:01:28:86:45
+    KE req   d=41983 e=31 f=9840  -> g=16
+    KE resp  h=20670
+    shared   = 20670**16 mod 41983 = 25182
+    key      = ef10cd7eeb72a06dc93c5b51da301e11
+    iv       = 09470abfaefc72cb9b5ab1ae0b865218  (from VERIFY frame)
+"""
+
+import struct
+
+from src.etekcity_esf551_ble.efsa591s import a5_protocol as p
+
+MAC = "CF:EA:01:28:86:45"
+REV_MAC = bytes.fromhex("45862801eacf")
+
+KE_REQ = bytes.fromhex("a52314160088010142000055592f6af00645862801eacfffa31f7026")
+KE_RESP = bytes.fromhex("a513140f001f0101420000000645862801eacfbe50")
+VERIFY = bytes.fromhex(
+    "a523152500860102420001f146fa4ff79667f73e080119110e0cddbfe3655b8794cb46664b14c9d9c73969"
+)
+MEAS = bytes.fromhex(
+    "a5033825008a012144000150242bf17c291c80514cf20804c2b26a627dfa6324a2c9dd53c449d800add65c"
+)
+
+KEY = bytes.fromhex("ef10cd7eeb72a06dc93c5b51da301e11")
+IV = bytes.fromhex("09470abfaefc72cb9b5ab1ae0b865218")
+SHARED = 25182
+
+
+class TestFraming:
+    def test_checksum_total_is_ff(self):
+        # every captured frame: sum of all bytes ≡ 0xFF (mod 256)
+        for fr in (KE_REQ, KE_RESP, VERIFY, MEAS):
+            assert sum(fr) % 256 == 0xFF
+
+    def test_build_frame_matches_checksum(self):
+        # rebuild the KE request body and confirm the checksum byte
+        payload = KE_REQ[11:]
+        frame = p.build_frame(0x14, p.OPCODE_KEY_EXCHANGE, payload, p.CHANNEL_PLAINTEXT)
+        assert frame == KE_REQ
+
+    def test_parse_frame(self):
+        f = p.parse_frame(KE_REQ)
+        assert f is not None
+        assert f.opcode == p.OPCODE_KEY_EXCHANGE
+        assert f.seq == 0x14
+        assert f.channel == p.CHANNEL_PLAINTEXT
+        assert f.payload == KE_REQ[11:]
+
+    def test_parse_frame_rejects_bad(self):
+        assert p.parse_frame(b"\x00\x01\x02") is None
+        assert p.parse_frame(KE_REQ[:-1]) is None  # truncated
+
+    def test_reassembler(self):
+        r = p.FrameReassembler()
+        # split MEAS into 20-byte chunks like BLE notifications
+        frames = []
+        for i in range(0, len(MEAS), 20):
+            frames.extend(r.feed(MEAS[i:i + 20]))
+        assert frames == [MEAS]
+
+
+class TestMacAndDH:
+    def test_reversed_mac(self):
+        assert p.reversed_mac_bytes(MAC) == REV_MAC
+
+    def test_dh_public_value(self):
+        # f = e**g mod d
+        assert pow(31, 16, 41983) == 9840
+
+    def test_compute_shared(self):
+        assert p.compute_shared(20670, 16, 41983) == SHARED
+
+    def test_derive_key_matches_capture(self):
+        assert p.derive_key(SHARED, MAC) == KEY
+
+    def test_generate_dh_is_valid(self):
+        dh = p.generate_dh()
+        assert p.DH_MOD_MIN <= dh.d <= p.DH_MOD_MAX
+        assert p.DH_BASE_MIN <= dh.e <= p.DH_BASE_MAX
+        assert p.DH_EXP_MIN <= dh.g <= p.DH_EXP_MAX
+        assert dh.f == pow(dh.e, dh.g, dh.d)
+
+
+class TestKeyExchange:
+    def test_parse_ke_response(self):
+        assert p.parse_key_exchange_response(KE_RESP) == 20670
+
+    def test_build_ke_request_roundtrip(self):
+        dh = p.DHParams(d=41983, e=31, g=16, f=9840)
+        frame = p.build_key_exchange(0x14, MAC, dh)
+        parsed = p.parse_frame(frame)
+        assert parsed.opcode == p.OPCODE_KEY_EXCHANGE
+        pl = parsed.payload
+        assert pl[5] == 6 and pl[6:12] == REV_MAC
+        assert struct.unpack("<H", pl[12:14])[0] == 41983
+        assert pl[14] == 31
+        assert struct.unpack("<H", pl[15:17])[0] == 9840
+
+
+class TestVerifyAndDecrypt:
+    def test_verify_frame_yields_iv(self):
+        # decrypt the captured VERIFY with (key, zero-IV) and pull the IV
+        parsed = p.parse_frame(VERIFY)
+        pt = p.decrypt_frame_payload(KEY, bytes(16), parsed)
+        assert pt[1:7] == REV_MAC
+        assert pt[7] == 16
+        assert pt[8:24] == IV
+
+    def test_build_verify_roundtrip(self):
+        frame = p.build_key_verify(0x15, MAC, IV, KEY)
+        parsed = p.parse_frame(frame)
+        assert parsed.opcode == p.OPCODE_KEY_VERIFY
+        assert parsed.channel == p.CHANNEL_AES
+        pt = p.decrypt_frame_payload(KEY, bytes(16), parsed)
+        assert pt[1:7] == REV_MAC
+        assert pt[8:24] == IV
+
+    def test_decrypt_measurement(self):
+        parsed = p.parse_frame(MEAS)
+        pt = p.decrypt_frame_payload(KEY, IV, parsed)
+        m = p.parse_measurement(pt)
+        assert m is not None
+        # session-1 first live frame: weight is grams (uint24 LE) / 1000
+        assert m.weight_kg == 11.2
+        assert m.impedance is None
+        assert m.final is False
+
+
+class TestResultFrame:
+    # decrypted 0x443a final-result frame (round 3 key): weight 111.25 kg, imp 424
+    RESULT_PT = bytes.fromhex(
+        "32323239313131325f5f5f5f5f5f5f5f5f5f5f5f000092b201a801000080592f6a0101015803"
+    )
+
+    def test_parse_result(self):
+        m = p.parse_result(self.RESULT_PT)
+        assert m is not None
+        assert m.weight_kg == 111.25
+        assert m.impedance == 424
+        assert m.final is True

--- a/tests/unit/test_efsa591s_a5_protocol.py
+++ b/tests/unit/test_efsa591s_a5_protocol.py
@@ -144,3 +144,12 @@ class TestResultFrame:
         assert m.weight_kg == 111.25
         assert m.impedance == 424
         assert m.final is True
+        assert m.heart_rate == 88  # byte[36] = 0x58
+
+    def test_parse_result_heart_rate_zero_is_none(self):
+        # byte[36] == 0 means HR not measured (stepped off early / not barefoot)
+        pt = bytearray(self.RESULT_PT)
+        pt[36] = 0
+        m = p.parse_result(bytes(pt))
+        assert m is not None
+        assert m.heart_rate is None


### PR DESCRIPTION
Adds support for the Etekcity EFS-A591S-KUS (the "Apex HR" model).

This one's a bit different from the ESF-551 and ESF-24. The measurement channel is AES-encrypted, and the key isn't fixed — it's negotiated per connection with a small Diffie-Hellman handshake that's also tied to the device's MAC. So most of this PR is implementing that handshake plus the "A5" frame format around it. Once the session key is set up, the measurements are just AES-CBC on the notify characteristic.

It reads weight and whole-body impedance straight off the scale, entirely locally — no cloud, no account. Body-composition values (BMI, body fat, muscle mass, etc.) are derived from weight + impedance using the existing BodyMetrics engine, and there's an EFSA591SScaleWithBodyMetrics wrapper that mirrors the ESF-551 one.

Everything new is self-contained in a new efsa591s/ package (a5_protocol.py for the framing/crypto/parsing, scale.py for the GATT client). The only changes outside it are the two exports in the top-level __init__.py and adding cryptography to the deps — no existing scale code is touched, so ESF-551/ESF-24/FIT8S are unaffected.

Unit tests cover the framing and checksum, the DH key agreement, key derivation, and measurement decoding, all pinned to real captured frames (the handshake request is reproduced byte-for-byte). I also verified it end-to-end on actual hardware — weight and impedance line up with what the scale displays.

A few things to know: key derivation needs the real MAC, so it won't work on macOS where bleak hands back a CoreBluetooth UUID instead of a MAC. It adds a cryptography dependency. And there's a small example CLI under examples/ if anyone wants to connect directly.

Disclosure: this was developed with significant help from Claude Opus (Anthropic's model) — working out the protocol, writing the implementation, and the tests. I've reviewed all of it and verified the behavior against real hardware.