### PR TITLE
Add display unit handling for the EFS-A591S-KUS

### DIFF
--- a/src/etekcity_esf551_ble/efsa591s/a5_protocol.py
+++ b/src/etekcity_esf551_ble/efsa591s/a5_protocol.py
@@ -257,6 +257,7 @@ class Measurement(NamedTuple):
     final: bool            # True for the 0x443a result frame
     raw: bytes
     heart_rate: int | None = None  # bpm, present on the final result once measured
+    display_unit: int | None = None  # unit shown on the scale: 0=kg, 1=lb, 2=st
 
 
 def decrypt_frame_payload(key: bytes, iv: bytes, parsed: ParsedFrame) -> bytes:
@@ -287,13 +288,21 @@ def parse_result(plaintext: bytes) -> Measurement | None:
 
     Layout (38 bytes): [0:8]=serial ascii, [8:20]=name, [20:22]=00,
     [22:25]=weight grams (uint24 LE) /1000 kg, [25:27]=impedance (uint16 LE) ohms,
-    [29:33]=timestamp, [36]=heart rate (bpm, 0 until measured).
+    [29:33]=timestamp, [35]=display unit (0=kg, 1=lb, 2=st),
+    [36]=heart rate (bpm, 0 until measured).
     """
     if len(plaintext) < 33:
         return None
     weight = int.from_bytes(plaintext[22:25], "little") / 1000.0
     impedance = struct.unpack("<H", plaintext[25:27])[0]
     timestamp = struct.unpack("<I", plaintext[29:33])[0]
+    # Display unit the scale showed this reading in. Same encoding as the ESF-551
+    # (0=kg, 1=lb, 2=st). Confirmed at byte[35] by a kg-vs-lb capture diff (it
+    # flips 1->0 between lb and kg while bytes 33/34 stay constant). Only 0/1/2
+    # are accepted; anything else is treated as "unknown".
+    display_unit = plaintext[35] if len(plaintext) >= 36 else None
+    if display_unit not in (0, 1, 2):
+        display_unit = None
     # Heart rate is one byte near the end of the frame; 0 means "not measured"
     # (e.g. user stepped off before it locked, or not barefoot on the electrodes).
     heart_rate = plaintext[36] if len(plaintext) >= 37 and plaintext[36] else None
@@ -302,4 +311,5 @@ def parse_result(plaintext: bytes) -> Measurement | None:
         impedance=impedance if 0 < impedance < 60000 else None,
         timestamp=timestamp, final=True, raw=plaintext,
         heart_rate=heart_rate,
+        display_unit=display_unit,
     )

--- a/src/etekcity_esf551_ble/efsa591s/a5_protocol.py
+++ b/src/etekcity_esf551_ble/efsa591s/a5_protocol.py
@@ -40,6 +40,7 @@ OPCODE_KEY_EXCHANGE = 0x4201   # OP_HIGH_SECURITY_KEY_EXCHANGE
 OPCODE_KEY_VERIFY = 0x4202     # OP_HIGH_SECURITY_KEY_VERIFY
 OPCODE_MEASUREMENT = 0x4421    # live weight push (resource 21 44 00)
 OPCODE_RESULT = 0x443a         # final result: weight + impedance (resource 3a 44 00)
+OPCODE_SET_UNIT = 0xa163       # config: set the scale's display unit (0=kg, 1=lb, 2=st)
 
 CHANNEL_PLAINTEXT = 0x00
 CHANNEL_AES = 0x01             # the AES-encrypted measurement channel
@@ -242,6 +243,21 @@ def build_key_verify(seq: int, mac: str, iv: bytes, key: bytes) -> bytes:
     inner = bytes([0x0C]) + rmac + bytes([len(iv)]) + iv
     ciphertext = _aes_cbc_encrypt(key, bytes(16), _pkcs7_pad(inner))
     return build_frame(seq, OPCODE_KEY_VERIFY, ciphertext, CHANNEL_AES)
+
+
+def build_set_unit(seq: int, unit: int, key: bytes, iv: bytes) -> bytes:
+    """
+    Build a display-unit change command (resource 0xa163).
+
+    The plaintext payload is a single byte = the desired unit (0=kg, 1=lb, 2=st),
+    AES-CBC/PKCS7 encrypted with the session (key, iv) and sent on the AES channel
+    to FFF2 — captured from the app, which writes exactly this on connect and on
+    any unit toggle.
+    """
+    if unit not in (0, 1, 2):
+        raise ValueError(f"unit must be 0 (kg), 1 (lb) or 2 (st); got {unit}")
+    ciphertext = _aes_cbc_encrypt(key, iv, _pkcs7_pad(bytes([unit])))
+    return build_frame(seq, OPCODE_SET_UNIT, ciphertext, CHANNEL_AES)
 
 
 def random_iv() -> bytes:

--- a/src/etekcity_esf551_ble/efsa591s/scale.py
+++ b/src/etekcity_esf551_ble/efsa591s/scale.py
@@ -111,6 +111,15 @@ class EFSA591SScale(GattScale):
         if self._client and self._write_char:
             await self._client.write_gatt_char(self._write_char, frame, response=False)
 
+    async def _send_verify_then_unit(
+        self, verify: bytes, unit_frame: bytes | None
+    ) -> None:
+        # VERIFY establishes the session; the unit command reuses the same key/iv,
+        # so it must go out after VERIFY (and only if a unit is configured).
+        await self._send_frame(verify)
+        if unit_frame is not None:
+            await self._send_frame(unit_frame)
+
     def _notification_handler(
         self,
         _: BleakGATTCharacteristic,
@@ -141,7 +150,15 @@ class EFSA591SScale(GattScale):
             verify = a5.build_key_verify(
                 self._next_seq(), self.address, self._iv, self._key
             )
-            asyncio.ensure_future(self._send_frame(verify))
+            # Push the configured display unit right after VERIFY, the same way
+            # the app does on connect (resource 0xa163, encrypted with the session
+            # key/iv). Skipped when no unit is configured.
+            unit_frame = None
+            if self._display_unit is not None:
+                unit_frame = a5.build_set_unit(
+                    self._next_seq(), int(self._display_unit), self._key, self._iv
+                )
+            asyncio.ensure_future(self._send_verify_then_unit(verify, unit_frame))
 
         elif parsed.opcode == a5.OPCODE_RESULT:
             # Only the final result frame carries the stabilized weight plus

--- a/src/etekcity_esf551_ble/efsa591s/scale.py
+++ b/src/etekcity_esf551_ble/efsa591s/scale.py
@@ -173,7 +173,13 @@ class EFSA591SScale(GattScale):
         scale_data.address = address
         scale_data.hw_version = self.hw_version or ""
         scale_data.sw_version = self.sw_version or ""
-        scale_data.display_unit = self._display_unit
+        # Prefer the unit the scale actually displayed this reading in (from the
+        # result frame); fall back to the client-configured unit if absent.
+        scale_data.display_unit = (
+            WeightUnit(meas.display_unit)
+            if meas.display_unit is not None
+            else self._display_unit
+        )
         measurements: dict[str, float | int] = {WEIGHT_KEY: meas.weight_kg}
         if meas.impedance:
             measurements[IMPEDANCE_KEY] = meas.impedance

--- a/tests/unit/test_efsa591s_a5_protocol.py
+++ b/tests/unit/test_efsa591s_a5_protocol.py
@@ -162,3 +162,34 @@ class TestResultFrame:
         m = p.parse_result(bytes(pt))
         assert m is not None
         assert m.heart_rate is None
+
+
+class TestSetUnit:
+    # Ground truth captured from the app (Frida): channel-1 session key/iv and the
+    # exact ciphertext the app's AES doFinal produced for each unit's 0xa163 write.
+    KEY = bytes.fromhex("c7780d30ff1e531cd89258386b4b9b0b")
+    IV = bytes.fromhex("bdbd7f418b52652c4fc29552736b1051")
+    CIPHERTEXT = {
+        0: "7b31dfe6f1db7baf68402299cbd934c0",  # kg
+        1: "2f8010a5274df10d308c1544cda350c5",  # lb
+        2: "6e06d4ad2e18dda2c0791628258cec91",  # st
+    }
+    # Full lb frame at seq 0x03 captured verbatim from the app's FFF2 write
+    # (validates flags + checksum + framing end to end).
+    LB_FRAME = "a523031500a90163a100012f8010a5274df10d308c1544cda350c5"
+
+    def test_build_set_unit_ciphertext_matches_app(self):
+        for unit, ct in self.CIPHERTEXT.items():
+            parsed = p.parse_frame(p.build_set_unit(0x03, unit, self.KEY, self.IV))
+            assert parsed.opcode == p.OPCODE_SET_UNIT
+            assert parsed.channel == p.CHANNEL_AES
+            assert parsed.payload.hex() == ct
+
+    def test_build_set_unit_full_frame_matches_capture(self):
+        assert p.build_set_unit(0x03, 1, self.KEY, self.IV).hex() == self.LB_FRAME
+
+    def test_build_set_unit_rejects_invalid_unit(self):
+        import pytest
+
+        with pytest.raises(ValueError):
+            p.build_set_unit(0x03, 5, self.KEY, self.IV)

--- a/tests/unit/test_efsa591s_a5_protocol.py
+++ b/tests/unit/test_efsa591s_a5_protocol.py
@@ -145,6 +145,15 @@ class TestResultFrame:
         assert m.impedance == 424
         assert m.final is True
         assert m.heart_rate == 88  # byte[36] = 0x58
+        assert m.display_unit == 1  # byte[35] = 0x01 = lb (capture was in lb)
+
+    def test_parse_result_display_unit_mapping(self):
+        # byte[35] encodes the scale's display unit: 0=kg, 1=lb, 2=st; other => None
+        # (confirmed by kg-vs-lb capture diff: byte[35] flips 1->0, bytes 33/34 constant)
+        for raw, expected in ((0, 0), (1, 1), (2, 2), (7, None)):
+            pt = bytearray(self.RESULT_PT)
+            pt[35] = raw
+            assert p.parse_result(bytes(pt)).display_unit == expected
 
     def test_parse_result_heart_rate_zero_is_none(self):
         # byte[36] == 0 means HR not measured (stepped off early / not barefoot)


### PR DESCRIPTION
Follow-up to #7 — adds the display-unit handling that was missing from the initial EFS-A591S merge.

**Read (which unit the scale displayed the reading in):** it's byte **35** of the decrypted `0x443a` result frame, immediately after the timestamp, encoded the same way as the ESF-551: `0=kg, 1=lb, 2=st`. Confirmed with a kg-vs-lb capture diff — byte 35 flips `1→0` between lb and kg while the neighbouring bytes stay constant. `parse_result` now reads it and `scale._emit` reports the scale's actual displayed unit (falling back to the configured one when absent).

**Set (change the unit):** the app uses a config write to resource **`0xa163`** — the same opcode the ESF-551 uses — but on this model the payload is AES-encrypted on the session channel rather than plaintext. The plaintext is a single byte = the desired unit (`0/1/2`), AES-CBC/PKCS7 with the session key/iv. `build_set_unit()` reproduces the app's exact ciphertext **and** full frame byte-for-byte for all three units, verified against captured frames. The client pushes the configured unit right after VERIFY, the same way the app does on connect.

Tests cover the byte-35 read mapping and the set-unit framing (ciphertext + full-frame match against the captured app writes, plus invalid-unit rejection).

I left the version unbumped — figured you'd rather set that on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)